### PR TITLE
12 メールの非同期送信を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,10 @@ gem 'mini_magick'
 gem 'config'
 # ページネーション
 gem 'kaminari'
+# 非同期処理
+gem 'sidekiq'
+ # ダッシュボードを利用するため
+gem 'sinatra', require: false
 
 gem 'jquery-rails'
 gem 'bootstrap', '>= 4.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'config'
 gem 'kaminari'
 # 非同期処理
 gem 'sidekiq'
- # ダッシュボードを利用するため
+# ダッシュボードを利用するため
 gem 'sinatra', require: false
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       activesupport (>= 4.2)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-schema (~> 1.0)
+    connection_pool (2.2.2)
     crass (1.0.5)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
@@ -191,6 +192,7 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.0.3)
     mysql2 (0.5.2)
     nio4r (2.5.2)
     nokogiri (1.10.4)
@@ -217,6 +219,8 @@ GEM
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -318,6 +322,16 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    sinatra (2.0.7)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.7)
+      tilt (~> 2.0)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -397,6 +411,8 @@ DEPENDENCIES
   rubocop (~> 0.75.1)
   rubocop-rails
   sass-rails (~> 5.0)
+  sidekiq
+  sinatra
   slim-rails
   sorcery
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,8 @@ module WrkInstaClone
 
     # 国際化対応
     config.i18n.default_locale = :ja
+
+    # 非同期処理
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 Sidekiq.configure_server do |config|
-	config.redis = { url: 'redis://localhost:6379'}
+  config.redis = { url: 'redis://localhost:6379' }
 end
 
 Sidekiq.configure_client do |config|
-	config.redis = { url: 'redis://localhost:6379'}
+  config.redis = { url: 'redis://localhost:6379' }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+	config.redis = { url: 'redis://localhost:6379'}
+end
+
+Sidekiq.configure_client do |config|
+	config.redis = { url: 'redis://localhost:6379'}
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: '/letter_opener'
+    mount Sidekiq::Web, at: '/sidekiq'
   end
   root 'posts#index'
   get    '/login',   to: 'sessions#new'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+:concurrency: 25
+:pidfile: ./tmp/pids/sidekiq.pid
+:logfile: ./log/sidekiq.log
+:queues:
+  - default
+  - mailers
+:daemon: true


### PR DESCRIPTION
## 概要
* sidekiqの導入
* ダッシュボード参照のため、sinatraも導入

## 確認方法

* `bundle exec sidekiq -C config/sidekiq.yml` を実行して、メール通知時にコンソールログが出力されること
* ダッシュボードで実行完了ジョブが増えていること

<img width="1275" alt="スクリーンショット 2019-12-10 22 40 26" src="https://user-images.githubusercontent.com/55390888/70534635-c90bd500-1b9e-11ea-8602-48aba48cd388.png">

## コメント
* sinatraを入れる理由は、sidekiq起動時に、ダッシュボードのページをhostingするローカルサーバーを立ち上げるのにsinatraを使っているというような理解で合っているでしょうか。
