### PR TITLE
Feature/13 notification settings

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    if @comment.save && @comment.post.user.notification_on_comment?
+    if @comment.save && current_user.notification_on_comment?
       UserMailer.with(
         user_from: current_user,
         user_to: @comment.post.user,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    if @comment.save && current_user.notification_on_comment?
+    if @comment.save && @comment.post.user.notification_on_comment?
       UserMailer.with(
         user_from: current_user,
         user_to: @comment.post.user,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    if @comment.save
+    if @comment.save && @comment.post.user.notification_on_comment?
       UserMailer.with(
         user_from: current_user,
         user_to: @comment.post.user,

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,7 +3,7 @@ class LikesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    if current_user.like(@post) && current_user.notification_on_like?
+    if current_user.like(@post) && @post.user.notification_on_like?
       UserMailer.with(
         user_from: current_user,
         user_to: @post.user,

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,7 +3,7 @@ class LikesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    if current_user.like(@post)
+    if current_user.like(@post) && @post.user.notification_on_like?
       UserMailer.with(
         user_from: current_user,
         user_to: @post.user,

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,7 +3,7 @@ class LikesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    if current_user.like(@post) && @post.user.notification_on_like?
+    if current_user.like(@post) && current_user.notification_on_like?
       UserMailer.with(
         user_from: current_user,
         user_to: @post.user,

--- a/app/controllers/mypage/notifications_controller.rb
+++ b/app/controllers/mypage/notifications_controller.rb
@@ -14,6 +14,7 @@ class Mypage::NotificationsController < Mypage::BaseController
   end
 
   private
+
   def user_params
     params.require(:user).permit(:notification_on_comment, :notification_on_follow, :notification_on_like)
   end

--- a/app/controllers/mypage/notifications_controller.rb
+++ b/app/controllers/mypage/notifications_controller.rb
@@ -1,0 +1,20 @@
+class Mypage::NotificationsController < Mypage::BaseController
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  def update
+    @user = User.find(current_user.id)
+    if @user.update(user_params)
+      redirect_to edit_mypage_notification_path, success: '設定を更新しました'
+    else
+      flash.now['danger'] = '設定の更新に失敗しました'
+      render :notifications
+    end
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:notification_on_comment, :notification_on_follow, :notification_on_like)
+  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @user = User.find(params[:followed_id])
-    if current_user.follow(@user) && @user.notification_on_follow?
+    if current_user.follow(@user) && current_user.notification_on_follow?
       UserMailer.with(
         user_from: current_user,
         user_to: @user

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @user = User.find(params[:followed_id])
-    if current_user.follow(@user) && current_user.notification_on_follow?
+    if current_user.follow(@user) && @user.notification_on_follow?
       UserMailer.with(
         user_from: current_user,
         user_to: @user

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,7 +3,7 @@ class RelationshipsController < ApplicationController
 
   def create
     @user = User.find(params[:followed_id])
-    if current_user.follow(@user)
+    if current_user.follow(@user) && @user.notification_on_follow?
       UserMailer.with(
         user_from: current_user,
         user_to: @user

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -7,7 +7,7 @@
 #  subject_id   :bigint
 #  user_id      :bigint
 #  action_type  :integer          not null
-#  read         :boolean          default(FALSE), not null
+#  read         :boolean          default("unread"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  name             :string(255)      not null
-#  email            :string(255)      not null
-#  crypted_password :string(255)
-#  salt             :string(255)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  avatar           :string(255)
+#  id                      :bigint           not null, primary key
+#  name                    :string(255)      not null
+#  email                   :string(255)      not null
+#  crypted_password        :string(255)
+#  salt                    :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  avatar                  :string(255)
+#  notification_on_comment :boolean          default(TRUE), not null
+#  notification_on_follow  :boolean          default(TRUE), not null
+#  notification_on_like    :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/app/views/mypage/notifications/edit.html.slim
+++ b/app/views/mypage/notifications/edit.html.slim
@@ -1,0 +1,12 @@
+= form_with model: @user, url: mypage_notification_path, local: true do |f|
+  = render 'shared/error_messages', object: @user
+  .form-group
+    = f.check_box :notification_on_comment
+    = f.label :notification_on_comment
+  .form-group
+    = f.check_box :notification_on_like
+    = f.label :notification_on_like
+  .form-group
+    = f.check_box :notification_on_follow
+    = f.label :notification_on_follow
+  = f.submit '更新する', class: 'btn btn-raised btn-primary'

--- a/app/views/mypage/notifications/edit.html.slim
+++ b/app/views/mypage/notifications/edit.html.slim
@@ -1,6 +1,3 @@
-p
-  | 相手にメールを送信するかの設定
-hr
 = form_with model: @user, url: mypage_notification_path, local: true do |f|
   = render 'shared/error_messages', object: @user
   .form-group

--- a/app/views/mypage/notifications/edit.html.slim
+++ b/app/views/mypage/notifications/edit.html.slim
@@ -1,3 +1,6 @@
+p
+  | 相手にメールを送信するかの設定
+hr
 = form_with model: @user, url: mypage_notification_path, local: true do |f|
   = render 'shared/error_messages', object: @user
   .form-group

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -6,3 +6,6 @@ nav
     li
       = link_to '通知一覧', mypage_activities_path
       hr
+    li
+      = link_to '通知設定', edit_mypage_notification_path
+      hr

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,9 @@ ja:
         password: 'パスワード'
         password_confirmation:  'パウワード確認'
         avatar: 'アバター'
+        notification_on_comment: 'コメント時の通知メール'
+        notification_on_follow: 'フォロー時の通知メール'
+        notification_on_like: 'いいね時の通知メール'
       post:
         content: 'テキスト'
         images: '画像'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
   namespace :mypage do
     resource :account, only: %i[edit update]
     resources :activities, only: %i[index]
+    resource :notification, only: %i[edit update]
   end
 end

--- a/db/migrate/20191215005623_add_column_users.rb
+++ b/db/migrate/20191215005623_add_column_users.rb
@@ -1,0 +1,7 @@
+class AddColumnUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :notification_on_comment, :boolean, default: true, null: false
+    add_column :users, :notification_on_follow, :boolean, default: true, null: false
+    add_column :users, :notification_on_like, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_21_213946) do
+ActiveRecord::Schema.define(version: 2019_12_15_005623) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "subject_type"
@@ -71,6 +71,9 @@ ActiveRecord::Schema.define(version: 2019_11_21_213946) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.boolean "notification_on_comment", default: true, null: false
+    t.boolean "notification_on_follow", default: true, null: false
+    t.boolean "notification_on_like", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  name             :string(255)      not null
-#  email            :string(255)      not null
-#  crypted_password :string(255)
-#  salt             :string(255)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                      :bigint           not null, primary key
+#  name                    :string(255)      not null
+#  email                   :string(255)      not null
+#  crypted_password        :string(255)
+#  salt                    :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  avatar                  :string(255)
+#  notification_on_comment :boolean          default(TRUE), not null
+#  notification_on_follow  :boolean          default(TRUE), not null
+#  notification_on_like    :boolean          default(TRUE), not null
 #
 # Indexes
 #


### PR DESCRIPTION
## 概要
* 通知設定を管理するカラムをUserテーブルに追加
* 通知設定をON/OFFできるようにマイページにVIEWを追加
* 通知設定がONのときのみ、相手にメール送信をするようにcontrollerを修正

## 確認方法
* テーブル定義変更しているので、 `rails db:migrate`  が必要です。
* メール通知設定をOFFにしているときは、相手へのメールが作成されないことを `http://localhost:3000/letter_opener` で確認

## コメント
* 　 ~~「メールの通知設定」は最初「受信設定」と勘違いしていました。仕様をよく見ると「送信設定」なので修正しました。~~
→　正しくは「受信設定」だったので、revertしました。
